### PR TITLE
custom gigya DateTimeFormat

### DIFF
--- a/src/Response/Response.php
+++ b/src/Response/Response.php
@@ -4,7 +4,6 @@ namespace Graze\Gigya\Response;
 
 use DateTimeImmutable;
 use DateTimeInterface;
-use DateTimeZone;
 use GuzzleHttp\Message\ResponseInterface as GuzzleResponseInterface;
 use Illuminate\Support\Collection;
 
@@ -72,11 +71,7 @@ class Response implements ResponseInterface
         $this->statusCode = (int)$this->popField('statusCode');
         $this->statusReason = $this->popField('statusReason');
         $this->callId = $this->popField('callId');
-        $this->time = DateTimeImmutable::createFromFormat(
-            static::DATE_TIME_FORMAT,
-            $this->popField('time'),
-            new DateTimeZone('UTC')
-        );
+        $this->time = DateTimeImmutable::createFromFormat(static::DATE_TIME_FORMAT, $this->popField('time'));
     }
 
     /**

--- a/src/Response/Response.php
+++ b/src/Response/Response.php
@@ -2,9 +2,9 @@
 
 namespace Graze\Gigya\Response;
 
-use DateTime;
 use DateTimeImmutable;
 use DateTimeInterface;
+use DateTimeZone;
 use GuzzleHttp\Message\ResponseInterface as GuzzleResponseInterface;
 use Illuminate\Support\Collection;
 
@@ -12,6 +12,8 @@ use Illuminate\Support\Collection;
 
 class Response implements ResponseInterface
 {
+    const DATE_TIME_FORMAT = 'Y-m-d\TH:i:s.uP';
+
     /**
      * @var array
      */
@@ -70,7 +72,11 @@ class Response implements ResponseInterface
         $this->statusCode = (int)$this->popField('statusCode');
         $this->statusReason = $this->popField('statusReason');
         $this->callId = $this->popField('callId');
-        $this->time = DateTimeImmutable::createFromFormat(DateTime::ATOM, $this->popField('time'));
+        $this->time = DateTimeImmutable::createFromFormat(
+            static::DATE_TIME_FORMAT,
+            $this->popField('time'),
+            new DateTimeZone('UTC')
+        );
     }
 
     /**

--- a/tests/unit/Response/ResponseFactoryTest.php
+++ b/tests/unit/Response/ResponseFactoryTest.php
@@ -2,9 +2,7 @@
 
 namespace Graze\Gigya\Test\Unit\Response;
 
-use DateTime;
 use DateTimeImmutable;
-use DateTimeZone;
 use Graze\Gigya\Exceptions\UnknownResponseException;
 use Graze\Gigya\Response\Response;
 use Graze\Gigya\Response\ResponseCollectionInterface;
@@ -19,6 +17,7 @@ use Mockery\MockInterface;
 
 class ResponseFactoryTest extends TestCase
 {
+
     /**
      * @var ResponseFactory
      */
@@ -28,6 +27,11 @@ class ResponseFactoryTest extends TestCase
      * @var MockInterface|\Graze\Gigya\Validation\GigyaResponseValidatorInterface
      */
     private $validator;
+
+    public static function setUpBeforeClass()
+    {
+        date_default_timezone_set('UTC');
+    }
 
     public function setUp()
     {
@@ -60,11 +64,7 @@ class ResponseFactoryTest extends TestCase
         static::assertEquals("e6f891ac17f24810bee6eb533524a152", $gigyaResponse->getCallId());
         static::assertInstanceOf('DateTimeInterface', $gigyaResponse->getTime());
         static::assertEquals(
-            DateTimeImmutable::createFromFormat(
-                Response::DATE_TIME_FORMAT,
-                "2015-03-22T11:42:25.943Z",
-                new DateTimeZone('UTC')
-            ),
+            DateTimeImmutable::createFromFormat(Response::DATE_TIME_FORMAT, "2015-03-22T11:42:25.943Z"),
             $gigyaResponse->getTime()
         );
         $data = $gigyaResponse->getData();

--- a/tests/unit/Response/ResponseFactoryTest.php
+++ b/tests/unit/Response/ResponseFactoryTest.php
@@ -6,6 +6,7 @@ use DateTime;
 use DateTimeImmutable;
 use DateTimeZone;
 use Graze\Gigya\Exceptions\UnknownResponseException;
+use Graze\Gigya\Response\Response;
 use Graze\Gigya\Response\ResponseCollectionInterface;
 use Graze\Gigya\Response\ResponseFactory;
 use Graze\Gigya\Test\TestCase;
@@ -57,7 +58,15 @@ class ResponseFactoryTest extends TestCase
         static::assertEquals(0, $gigyaResponse->getErrorCode());
         static::assertEquals("OK", $gigyaResponse->getStatusReason());
         static::assertEquals("e6f891ac17f24810bee6eb533524a152", $gigyaResponse->getCallId());
-        static::assertEquals(DateTimeImmutable::createFromFormat(DateTime::ATOM, "2015-03-22T11:42:25.943Z"), $gigyaResponse->getTime());
+        static::assertInstanceOf('DateTimeInterface', $gigyaResponse->getTime());
+        static::assertEquals(
+            DateTimeImmutable::createFromFormat(
+                Response::DATE_TIME_FORMAT,
+                "2015-03-22T11:42:25.943Z",
+                new DateTimeZone('UTC')
+            ),
+            $gigyaResponse->getTime()
+        );
         $data = $gigyaResponse->getData();
         static::assertEquals("_gid_30A3XVJciH95WEEnoRmfZS7ee3MY+lUAtpVxvUWNseU=", $data->get('UID'));
         static::assertSame($response, $gigyaResponse->getOriginalResponse());

--- a/tests/unit/Response/ResponseTest.php
+++ b/tests/unit/Response/ResponseTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Graze\Gigya\Test\Unit\Response;
+
+use DateTime;
+use DateTimeZone;
+use Graze\Gigya\Response\Response;
+use Graze\Gigya\Test\TestCase;
+
+class ResponseTest extends TestCase
+{
+    public function testDateFormat()
+    {
+        $time = DateTime::createFromFormat(
+            Response::DATE_TIME_FORMAT,
+            '2015-03-22T11:42:25.943Z',
+            new DateTimeZone('UTC')
+        );
+
+        static::assertInstanceOf('DateTimeInterface', $time);
+        static::assertEquals("2015", $time->format('Y'));
+        static::assertEquals("03", $time->format('m'));
+        static::assertEquals("22", $time->format('d'));
+        static::assertEquals("11", $time->format('H'));
+        static::assertEquals("42", $time->format('i'));
+        static::assertEquals("25", $time->format('s'));
+        static::assertEquals("943000", $time->format('u'));
+        static::assertEquals("Z", $time->getTimezone()->getName());
+    }
+
+    public function testOtherTimeZoneFormat()
+    {
+        $time = DateTime::createFromFormat(
+            Response::DATE_TIME_FORMAT,
+            '2015-03-22T11:42:25.943+02:00',
+            new DateTimeZone('UTC')
+        );
+
+        static::assertInstanceOf('DateTimeInterface', $time);
+        static::assertEquals("2015", $time->format('Y'));
+        static::assertEquals("03", $time->format('m'));
+        static::assertEquals("22", $time->format('d'));
+        static::assertEquals("11", $time->format('H'));
+        static::assertEquals("42", $time->format('i'));
+        static::assertEquals("25", $time->format('s'));
+        static::assertEquals("943000", $time->format('u'));
+        static::assertEquals("+02:00", $time->getTimezone()->getName());
+    }
+}

--- a/tests/unit/Response/ResponseTest.php
+++ b/tests/unit/Response/ResponseTest.php
@@ -3,19 +3,19 @@
 namespace Graze\Gigya\Test\Unit\Response;
 
 use DateTime;
-use DateTimeZone;
 use Graze\Gigya\Response\Response;
 use Graze\Gigya\Test\TestCase;
 
 class ResponseTest extends TestCase
 {
+    public static function setUpBeforeClass()
+    {
+        date_default_timezone_set('UTC');
+    }
+
     public function testDateFormat()
     {
-        $time = DateTime::createFromFormat(
-            Response::DATE_TIME_FORMAT,
-            '2015-03-22T11:42:25.943Z',
-            new DateTimeZone('UTC')
-        );
+        $time = DateTime::createFromFormat(Response::DATE_TIME_FORMAT, '2015-03-22T11:42:25.943Z');
 
         static::assertInstanceOf('DateTimeInterface', $time);
         static::assertEquals("2015", $time->format('Y'));
@@ -30,11 +30,7 @@ class ResponseTest extends TestCase
 
     public function testOtherTimeZoneFormat()
     {
-        $time = DateTime::createFromFormat(
-            Response::DATE_TIME_FORMAT,
-            '2015-03-22T11:42:25.943+02:00',
-            new DateTimeZone('UTC')
-        );
+        $time = DateTime::createFromFormat(Response::DATE_TIME_FORMAT, '2015-03-22T11:42:25.943+02:00');
 
         static::assertInstanceOf('DateTimeInterface', $time);
         static::assertEquals("2015", $time->format('Y'));


### PR DESCRIPTION
Use a custom DateTimeFormat for the ISO8601 time as PHP has 2 different formats for it but neither work.

Resolves #7

