### PR TITLE
[#24] Passes credentials into body instead of as query parameters

### DIFF
--- a/tests/integration/GigyaTest.php
+++ b/tests/integration/GigyaTest.php
@@ -62,8 +62,8 @@ class GigyaTest extends TestCase
         static::assertCount(1, $store);
         $log = array_pop($store);
         static::assertEquals(
-            'https://accounts.eu1.gigya.com/accounts.getAccountInfo?apiKey=key&secret=secret',
-            $log['request']->getUri()->__toString()
+            'apiKey=key&secret=secret',
+            $log['request']->getBody()->__toString()
         );
     }
 
@@ -84,8 +84,8 @@ class GigyaTest extends TestCase
         $request = $log['request'];
         static::assertInstanceOf(RequestInterface::class, $request);
         static::assertEquals(
-            'https://accounts.eu1.gigya.com/accounts.getAccountInfo?apiKey=key&secret=secret&userKey=userKey',
-            $request->getUri()->__toString()
+            'apiKey=key&secret=secret&userKey=userKey',
+            $request->getBody()->__toString()
         );
     }
 
@@ -123,7 +123,7 @@ class GigyaTest extends TestCase
         static::assertCount(1, $store);
         $log = array_pop($store);
         static::assertEquals(
-            "https://accounts.eu1.gigya.com/accounts.getAccountInfo?uid=$uid&apiKey=key&secret=secret",
+            "https://accounts.eu1.gigya.com/accounts.getAccountInfo?uid=$uid",
             $log['request']->getUri()->__toString()
         );
 

--- a/tests/unit/Auth/HttpsAuthMiddlewareTest.php
+++ b/tests/unit/Auth/HttpsAuthMiddlewareTest.php
@@ -29,9 +29,9 @@ class HttpsAuthMiddlewareTest extends TestCase
     {
         $handler = new MockHandler([
             function (RequestInterface $request) {
-                $query = $request->getUri()->getQuery();
-                $this->assertRegExp('/apiKey=key/', $query);
-                $this->assertRegExp('/secret=secret/', $query);
+                $body = $request->getBody()->__toString();
+                $this->assertRegExp('/apiKey=key/', $body);
+                $this->assertRegExp('/secret=secret/', $body);
                 return new Response(200);
             },
         ]);
@@ -49,10 +49,10 @@ class HttpsAuthMiddlewareTest extends TestCase
     {
         $handler = new MockHandler([
             function (RequestInterface $request) {
-                $query = $request->getUri()->getQuery();
-                $this->assertRegExp('/apiKey=key/', $query);
-                $this->assertRegExp('/secret=secret/', $query);
-                $this->assertRegExp('/userKey=user/', $query);
+                $body = $request->getBody()->__toString();
+                $this->assertRegExp('/apiKey=key/', $body);
+                $this->assertRegExp('/secret=secret/', $body);
+                $this->assertRegExp('/userKey=user/', $body);
                 return new Response(200);
             },
         ]);


### PR DESCRIPTION
Gigya seems to not allow anymore to pass apikey and secret in query uri. So this PR passes it in request body instead.
 
Resolves #24
