### PR TITLE
Updated illuminate/support version in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": "^5.5|^7.0",
         "guzzlehttp/guzzle": "^6.2",
-        "illuminate/support": "^5.0"
+        "illuminate/support": "^5.0|^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.36 | ^5.2",


### PR DESCRIPTION
Updated illuminate/support version in composer.json to support Laravel
versions ^5.0, ^6.0 and ^7.0.

All tests have been completed successfully via `make test.`